### PR TITLE
feat: replace next button with newest and random buttons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -199,6 +199,7 @@
             font-family: inherit;
             transition: all 0.3s ease;
             box-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+            margin: 0 10px;
         }
 
         .next-btn:hover {
@@ -606,7 +607,8 @@
                 </div>
                 
                 <div class="random-controls">
-                    <button class="next-btn" id="nextRandomBtn">next</button>
+                    <button class="next-btn" id="newestBtn">newest</button>
+                    <button class="next-btn" id="randomBtn">random</button>
                 </div>
                 
                 <div class="random-info">

--- a/docs/js/gallery.js
+++ b/docs/js/gallery.js
@@ -41,7 +41,11 @@ class PixelGallery {
         });
 
         // Random controls
-        document.getElementById('nextRandomBtn').addEventListener('click', () => {
+        document.getElementById('newestBtn').addEventListener('click', () => {
+            this.showNewest();
+        });
+        
+        document.getElementById('randomBtn').addEventListener('click', () => {
             this.nextRandom();
         });
 
@@ -103,13 +107,15 @@ class PixelGallery {
         }
 
         const loadingOverlay = document.getElementById('loadingOverlay');
-        const nextBtn = document.getElementById('nextRandomBtn');
+        const newestBtn = document.getElementById('newestBtn');
+        const randomBtn = document.getElementById('randomBtn');
         const randomImage = document.getElementById('randomImage');
         const randomTitle = document.getElementById('randomTitle');
         const randomMeta = document.getElementById('randomMeta');
         
         loadingOverlay.style.display = 'flex';
-        nextBtn.disabled = true;
+        newestBtn.disabled = true;
+        randomBtn.disabled = true;
         
         // Preload image
         const img = new Image();
@@ -119,7 +125,8 @@ class PixelGallery {
             randomMeta.textContent = this.formatDate(artwork.date);
             
             loadingOverlay.style.display = 'none';
-            nextBtn.disabled = false;
+            newestBtn.disabled = false;
+            randomBtn.disabled = false;
         };
         img.onerror = () => {
             console.error('Failed to load image:', artwork.original);
@@ -129,13 +136,26 @@ class PixelGallery {
             randomMeta.textContent = this.formatDate(artwork.date);
             
             loadingOverlay.style.display = 'none';
-            nextBtn.disabled = false;
+            newestBtn.disabled = false;
+            randomBtn.disabled = false;
         };
         img.src = artwork.original;
     }
 
     nextRandom() {
         this.currentRandomIndex = Math.floor(Math.random() * this.artworks.length);
+        this.showRandomArtwork();
+    }
+
+    showNewest() {
+        if (this.artworks.length === 0) return;
+        
+        // Sort by date to find the newest artwork
+        const sortedArtworks = [...this.artworks].sort((a, b) => new Date(b.date) - new Date(a.date));
+        const newestArtwork = sortedArtworks[0];
+        
+        // Find the index of the newest artwork in the original array
+        this.currentRandomIndex = this.artworks.findIndex(artwork => artwork.id === newestArtwork.id);
         this.showRandomArtwork();
     }
 


### PR DESCRIPTION
Replace single "next" button with two buttons: "newest" and "random"

## Changes
- Add showNewest() function to display the most recent artwork by date
- Update button styling to include margins for proper spacing
- Update JavaScript event listeners and disable/enable logic for both buttons

Closes #12

Generated with [Claude Code](https://claude.ai/code)